### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,27 +6,27 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-DCC_Decoder KEYWORD1
+DCC_Decoder	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-SetupDecoder KEYWORD2
-SetupMonitor KEYWORD2
-SetIdlePacketHandler KEYWORD2
-SetResetPacketHandler KEYWORD2
-SetRawPacketHandler KEYWORD2
-SetBasicAccessoryDecoderPacketHandler KEYWORD2
-SetExtendedAccessoryDecoderPacketHandler KEYWORD2
-SetBaselineControlPacketHandler KEYWORD2
-SetDecodingEngineCompletionStatusHandler KEYWORD2
-ReadCV KEYWORD2
-WriteCV KEYWORD2
-MakePacketString KEYWORD2
-ResultString KEYWORD2
-loop KEYWORD2
-Address KEYWORD2
+SetupDecoder	KEYWORD2
+SetupMonitor	KEYWORD2
+SetIdlePacketHandler	KEYWORD2
+SetResetPacketHandler	KEYWORD2
+SetRawPacketHandler	KEYWORD2
+SetBasicAccessoryDecoderPacketHandler	KEYWORD2
+SetExtendedAccessoryDecoderPacketHandler	KEYWORD2
+SetBaselineControlPacketHandler	KEYWORD2
+SetDecodingEngineCompletionStatusHandler	KEYWORD2
+ReadCV	KEYWORD2
+WriteCV	KEYWORD2
+MakePacketString	KEYWORD2
+ResultString	KEYWORD2
+loop	KEYWORD2
+Address	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords